### PR TITLE
Remove the Issue.modified

### DIFF
--- a/jira_offline/cli/main.py
+++ b/jira_offline/cli/main.py
@@ -109,7 +109,7 @@ def cli_diff(_, key: str=None):
 
     else:
         for issue in jira.values():
-            if issue.diff_to_original and issue.exists:
+            if issue.modified and issue.exists:
                 print_diff(issue)
 
 

--- a/jira_offline/cli/main.py
+++ b/jira_offline/cli/main.py
@@ -320,6 +320,9 @@ def cli_new(_, projectkey: str, issuetype: str, summary: str, as_json: bool=Fals
     # Create an Issue offline, it is sync'd on push
     new_issue = create_issue(project, issuetype, summary, **kwargs)
 
+    # Write changes to disk
+    jira.write_issues()
+
     # Display the new issue
     if as_json:
         output = new_issue.as_json()
@@ -402,7 +405,6 @@ def cli_edit(_, key: str, as_json: bool=False, editor: bool=False, **kwargs):
 
     # Patch the issue with fields from the CLI or editor
     patch_issue_from_dict(issue, patch_dict)
-    issue.commit()
 
     jira.write_issues()
 

--- a/jira_offline/cli/project.py
+++ b/jira_offline/cli/project.py
@@ -94,7 +94,7 @@ def cli_project_delete(ctx: click.core.Context, projectkey: str):
     # Access the private DataFrame so to be sure no filter is applied
     df = jira._df  # pylint: disable=protected-access
 
-    if len(df[(df.project_key == projectkey) & (df.id > 0) & df.modified]):
+    if len(df[(df.project_key == projectkey) & (df.id > 0) & df.diff_to_original]):
         click.confirm('You have local modified changes which will be lost. Continue?', abort=True)
 
     del jira.config.projects[project.id]

--- a/jira_offline/cli/project.py
+++ b/jira_offline/cli/project.py
@@ -94,7 +94,7 @@ def cli_project_delete(ctx: click.core.Context, projectkey: str):
     # Access the private DataFrame so to be sure no filter is applied
     df = jira._df  # pylint: disable=protected-access
 
-    if len(df[(df.project_key == projectkey) & (df.id > 0) & df.diff_to_original]):
+    if len(df[(df.project_key == projectkey) & (df.id > 0) & df.modified]):
         click.confirm('You have local modified changes which will be lost. Continue?', abort=True)
 
     del jira.config.projects[project.id]

--- a/jira_offline/create.py
+++ b/jira_offline/create.py
@@ -89,12 +89,6 @@ def create_issue(project: ProjectMeta, issuetype: str, summary: str, **kwargs) -
 
     patch_issue_from_dict(new_issue, kwargs)
 
-    # Set into jira dict, and the underlying DataFrame
-    jira[new_issue.key] = new_issue
-
-    # Write changes to disk
-    jira.write_issues()
-
     return new_issue
 
 
@@ -138,7 +132,6 @@ def _import_modified_issue(attrs: dict, lineno: int=None) -> Issue:
         raise ImportFailed('Unknown issue key', lineno)
 
     patch_issue_from_dict(issue, attrs)
-    issue.commit()
 
     return issue
 
@@ -250,3 +243,6 @@ def patch_issue_from_dict(issue: Issue, attrs: dict):
     if attrs.get('epic_link'):
         matched_epic = find_epic_by_reference(attrs['epic_link'])
         issue.epic_link = matched_epic.key
+
+    # Commit issue object changes back into the DataFrame
+    issue.commit()

--- a/jira_offline/exceptions.py
+++ b/jira_offline/exceptions.py
@@ -251,11 +251,6 @@ class ImportFailed(DynamicBaseAppException):
         return msg
 
 
-# Raised by Issue.__set_attr__ when setting issue.original with direct assignment
-class CannotSetIssueOriginalDirectly(Exception):
-    'This attribute must not be set directly, use the set_original() helper'
-
-
 # Raised by Jira.update when a sync returns Issues with a different timezone to those already present
 class MultipleTimezoneError(Exception):
     '''A change Jira of timezone is unsupported, please run:

--- a/jira_offline/jira.py
+++ b/jira_offline/jira.py
@@ -120,8 +120,8 @@ class Jira(collections.abc.MutableMapping):
             inplace=True,
         )
 
-        # Render diff_to_original as a string for storage in the DataFrame
-        df['diff_to_original'] = df['diff_to_original'].apply(
+        # Render modified as a string for storage in the DataFrame
+        df['modified'] = df['modified'].apply(
             lambda x: json.dumps(x) if x else False
         )
 
@@ -256,7 +256,7 @@ class Jira(collections.abc.MutableMapping):
                 'project_id', 'issuetype', 'summary', 'key', 'assignee', 'created',
                 'creator', 'description', 'fix_versions', 'components', 'id', 'labels',
                 'priority', 'reporter', 'status', 'updated', 'epic_link', 'epic_name',
-                'sprint', 'story_points', 'extended', 'diff_to_original',
+                'sprint', 'story_points', 'extended', 'modified',
                 'project_key', 'original', 'parent_link'
             ])
 
@@ -266,7 +266,7 @@ class Jira(collections.abc.MutableMapping):
         Dump issues to feather cache file.
         '''
         # Make a copy of the DataFrame, for munging before write
-        # Don't write out the original field as it can be recreated from Issue.diff_to_original
+        # Don't write out the original field as it can be recreated from Issue.modified
         df = self._df.drop(columns=['original'])
 
         # Cleanup extended customfields columns

--- a/jira_offline/jira.py
+++ b/jira_offline/jira.py
@@ -121,7 +121,9 @@ class Jira(collections.abc.MutableMapping):
         )
 
         # Render diff_to_original as a string for storage in the DataFrame
-        df['diff_to_original'] = df['diff_to_original'].apply(json.dumps)
+        df['diff_to_original'] = df['diff_to_original'].apply(
+            lambda x: json.dumps(x) if x else False
+        )
 
         # Add an empty column to for Issue.original
         df['original'] = ''
@@ -254,7 +256,7 @@ class Jira(collections.abc.MutableMapping):
                 'project_id', 'issuetype', 'summary', 'key', 'assignee', 'created',
                 'creator', 'description', 'fix_versions', 'components', 'id', 'labels',
                 'priority', 'reporter', 'status', 'updated', 'epic_link', 'epic_name',
-                'sprint', 'story_points', 'extended', 'diff_to_original', 'modified',
+                'sprint', 'story_points', 'extended', 'diff_to_original',
                 'project_key', 'original', 'parent_link'
             ])
 

--- a/jira_offline/sync.py
+++ b/jira_offline/sync.py
@@ -224,7 +224,7 @@ def merge_issues(base_issue: Issue, updated_issue: Issue, is_upstream_merge: boo
         # this ensures the correct diff is written to disk
         update_obj.merged_issue.set_original(updated_issue.serialize())
 
-    # Refresh merged Issue's diff_to_original field
+    # Refresh merged Issue's modified field
     update_obj.merged_issue.diff()
 
     return update_obj
@@ -271,7 +271,7 @@ def build_update(base_issue: Issue, updated_issue: Optional[Issue]) -> IssueUpda
     updated_issue_dict: dict = updated_issue.serialize()
 
     # fields to ignore during dictdiffer.diff
-    ignore_fields = set(['diff_to_original', 'modified'])
+    ignore_fields = set(['modified', 'modified'])
 
     if updated_issue != Issue.blank():
         # ignore readonly fields when diffing new Issues
@@ -466,7 +466,7 @@ def push_issues() -> int:
     # 1. Push new issues; those created offline
     issues_to_push = jira.df.loc[jira.df.id == 0, 'key'].tolist()
     # 2. Push modified issues
-    issues_to_push += jira.df.loc[(jira.df.id > 0) & jira.df.diff_to_original, 'key'].tolist()
+    issues_to_push += jira.df.loc[(jira.df.id > 0) & jira.df.modified, 'key'].tolist()
 
     from jira_offline.cli.params import context  # pylint: disable=import-outside-toplevel, cyclic-import
 

--- a/jira_offline/sync.py
+++ b/jira_offline/sync.py
@@ -466,7 +466,7 @@ def push_issues() -> int:
     # 1. Push new issues; those created offline
     issues_to_push = jira.df.loc[jira.df.id == 0, 'key'].tolist()
     # 2. Push modified issues
-    issues_to_push += jira.df.loc[(jira.df.id > 0) & jira.df.modified, 'key'].tolist()
+    issues_to_push += jira.df.loc[(jira.df.id > 0) & jira.df.diff_to_original, 'key'].tolist()
 
     from jira_offline.cli.params import context  # pylint: disable=import-outside-toplevel, cyclic-import
 

--- a/jira_offline/utils/cli.py
+++ b/jira_offline/utils/cli.py
@@ -158,7 +158,7 @@ def parse_editor_result(issue: Issue, editor_result_raw: str, conflicts: Optiona
     issue_fields_by_friendly: Dict[str, str] = {
         friendly_title(Issue, f.name):f.name
         for f in dataclasses.fields(Issue)
-        if f.name not in ('extended', 'original', 'diff_to_original', '_active', 'modified')
+        if f.name not in ('extended', 'original', 'modified', '_active', 'modified')
     }
 
     if issue.extended:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -83,7 +83,7 @@ def mock_jira(mock_jira_core):
         'project_id', 'issuetype', 'summary', 'key', 'assignee', 'created',
         'creator', 'description', 'fix_versions', 'components', 'id', 'labels',
         'priority', 'reporter', 'status', 'updated', 'epic_link', 'epic_name',
-        'sprint', 'story_points', 'extended', 'diff_to_original',
+        'sprint', 'story_points', 'extended', 'modified',
         'project_key', 'parent_link',
     ])
     mock_jira_core.load_issues = mock.Mock()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -83,7 +83,7 @@ def mock_jira(mock_jira_core):
         'project_id', 'issuetype', 'summary', 'key', 'assignee', 'created',
         'creator', 'description', 'fix_versions', 'components', 'id', 'labels',
         'priority', 'reporter', 'status', 'updated', 'epic_link', 'epic_name',
-        'sprint', 'story_points', 'extended', 'diff_to_original', 'modified',
+        'sprint', 'story_points', 'extended', 'diff_to_original',
         'project_key', 'parent_link',
     ])
     mock_jira_core.load_issues = mock.Mock()

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -17,7 +17,7 @@ ISSUE_1 = {
     'updated': '2019-08-20T16:41:19',
     'epic_link': 'TEST-1',
     'story_points': '1',
-    'diff_to_original': [],
+    'modified': [],
 }
 
 ISSUE_NEW = {
@@ -44,7 +44,7 @@ EPIC_1 = {
     'summary': 'This is an epic',
     'updated': '2019-08-27T16:41:19',
     'epic_name': '0.1: Epic about a thing',
-    'diff_to_original': [],
+    'modified': [],
 }
 
 EPIC_NEW = {

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -18,7 +18,6 @@ ISSUE_1 = {
     'epic_link': 'TEST-1',
     'story_points': '1',
     'diff_to_original': [],
-    'modified': False,
 }
 
 ISSUE_NEW = {
@@ -46,7 +45,6 @@ EPIC_1 = {
     'updated': '2019-08-27T16:41:19',
     'epic_name': '0.1: Epic about a thing',
     'diff_to_original': [],
-    'modified': False,
 }
 
 EPIC_NEW = {

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -51,7 +51,7 @@ def setup_jira_dataframe_helper(issues: List[Issue]):
         keys=[i.key for i in issues]
     ).T
 
-    df = df.fillna('').convert_dtypes()
+    df = df.convert_dtypes()
 
     # convert all datetimes to UTC, where they are non-null (this is all non-new issues)
     for col in ('created', 'updated'):

--- a/test/models/test_issue.py
+++ b/test/models/test_issue.py
@@ -15,7 +15,7 @@ def test_issue_model__modified_is_false_after_constructor(project):
     Ensure Issue.modified is False after the object constructed
     '''
     issue = Issue.deserialize(ISSUE_1, project)
-    assert issue.modified is False
+    assert bool(issue.modified) is False
 
 
 def test_issue_model__blank_returns_valid_issue(project):
@@ -66,9 +66,9 @@ def test_issue_model__original_is_set_after_constructor(project):
     assert issue.original is not None
 
 
-def test_issue_model__diff_sets_issue_diff_to_original(project):
+def test_issue_model__diff_sets_issue_modified(project):
     '''
-    Ensure Issue.diff sets Issue.diff_to_original
+    Ensure Issue.diff sets Issue.modified
     '''
     issue = Issue.deserialize(ISSUE_1, project)
 
@@ -76,7 +76,7 @@ def test_issue_model__diff_sets_issue_diff_to_original(project):
     issue.assignee = 'eggbert'
     issue.diff()
 
-    assert issue.diff_to_original == [('change', 'assignee', ('eggbert', 'danil1'))]
+    assert issue.modified == [('change', 'assignee', ('eggbert', 'danil1'))]
 
 
 def test_issue_model__set_original_doesnt_set_modified_true(project):
@@ -87,21 +87,21 @@ def test_issue_model__set_original_doesnt_set_modified_true(project):
 
     issue.set_original(issue.serialize())
 
-    assert issue.modified is False
+    assert bool(issue.modified) is False
 
 
-def test_issue_model__set_original_removes_diff_to_original_field(project):
+def test_issue_model__set_original_removes_modified_field(project):
     '''
-    Ensure Issue.set_original does not retain the Issue.diff_to_original field created by Issue.diff
+    Ensure Issue.set_original does not retain the Issue.modified field created by Issue.diff
     '''
     with mock.patch.dict(ISSUE_1, {'key': 'TEST-72'}):
         issue = modified_issue_helper(Issue.deserialize(ISSUE_1, project), assignee='hoganp')
 
-    assert bool(issue.diff_to_original)
+    assert bool(issue.modified)
 
     issue.set_original(issue.serialize())
 
-    assert 'diff_to_original' not in issue.original
+    assert 'modified' not in issue.original
 
 
 def test_issue_model__original_not_updated_during_attribute_set(project):
@@ -140,13 +140,13 @@ def test_issue_model__commit__produces_issue_with_diff(mock_jira, project):
 
     issue.assignee = 'hoganp'
 
-    assert issue.modified is False
+    assert bool(issue.modified) is False
 
     with mock.patch('jira_offline.jira.jira', mock_jira):
         issue.commit()
 
     assert issue.assignee == 'hoganp'
-    assert issue.modified is True
+    assert bool(issue.modified) is True
     assert issue.diff() == [('change', 'assignee', ('hoganp', 'danil1'))]
 
     assert mock_jira['TEST-71'].assignee == 'hoganp'

--- a/test/sync/test_merge_issues.py
+++ b/test/sync/test_merge_issues.py
@@ -42,7 +42,6 @@ def test_merge_issues__merged_issue_has_original_property_updated_to_match_upstr
 
     serialized_upstream_issue = updated_issue.serialize()
     del serialized_upstream_issue['diff_to_original']
-    del serialized_upstream_issue['modified']
 
     # validate Issue.original updated to match `updated_issue`
     assert update_obj.merged_issue.original == serialized_upstream_issue
@@ -87,7 +86,6 @@ def test_merge_issues__is_upstream_merge_equals_true__merged_issue_original_equa
 
     serialized_upstream_issue = updated_issue.serialize()
     del serialized_upstream_issue['diff_to_original']
-    del serialized_upstream_issue['modified']
 
     # validate Issue.original updated to match `updated_issue`
     assert update_obj.merged_issue.original == serialized_upstream_issue

--- a/test/sync/test_merge_issues.py
+++ b/test/sync/test_merge_issues.py
@@ -41,15 +41,15 @@ def test_merge_issues__merged_issue_has_original_property_updated_to_match_upstr
     update_obj = merge_issues(local_issue, updated_issue, is_upstream_merge=True)
 
     serialized_upstream_issue = updated_issue.serialize()
-    del serialized_upstream_issue['diff_to_original']
+    del serialized_upstream_issue['modified']
 
     # validate Issue.original updated to match `updated_issue`
     assert update_obj.merged_issue.original == serialized_upstream_issue
 
 
-def test_merge_issues__merged_issue_has_diff_to_original(project):
+def test_merge_issues__merged_issue_has_modified(project):
     '''
-    Ensure the Issue returned from merge_issues has a diff_to_original attribute
+    Ensure the Issue returned from merge_issues has a modified attribute
     '''
     with mock.patch.dict(ISSUE_1, {'key': 'TEST-71'}):
         local_issue = Issue.deserialize(ISSUE_1, project)
@@ -58,7 +58,7 @@ def test_merge_issues__merged_issue_has_diff_to_original(project):
 
     update_obj = merge_issues(local_issue, updated_issue, is_upstream_merge=True)
 
-    assert update_obj.merged_issue.diff_to_original != []
+    assert update_obj.merged_issue.modified != []
 
 
 @mock.patch('jira_offline.sync.build_update')
@@ -85,7 +85,7 @@ def test_merge_issues__is_upstream_merge_equals_true__merged_issue_original_equa
     update_obj = merge_issues(local_issue, updated_issue, is_upstream_merge=True)
 
     serialized_upstream_issue = updated_issue.serialize()
-    del serialized_upstream_issue['diff_to_original']
+    del serialized_upstream_issue['modified']
 
     # validate Issue.original updated to match `updated_issue`
     assert update_obj.merged_issue.original == serialized_upstream_issue

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -461,7 +461,8 @@ def test_create__patch_issue_from_dict__set_list(mock_jira, project, param):
 
     assert issue.labels == ['egg']
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'labels': param})
 
     assert issue.labels == ['egg', 'bacon']

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -14,7 +14,8 @@ def test_create__create_issue__loads_issues_when_cache_empty(mock_jira, project)
     '''
     Ensure create_issue() calls load_issues() when the cache is empty
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         create_issue(project, 'Story', 'This is a summary')
 
     assert mock_jira.load_issues.called
@@ -27,7 +28,8 @@ def test_create__create_issue__does_not_load_issues_when_cache_full(mock_jira, p
     # add an Issue fixture to the Jira dict
     mock_jira['TEST-72'] = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         create_issue(project, 'Story', 'This is a summary')
 
     assert not mock_jira.load_issues.called
@@ -37,27 +39,29 @@ def test_create__create_issue__raises_on_invalid_issuetype(mock_jira, project):
     '''
     Ensure create_issue() raises an exception on an invalid issuetype
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         with pytest.raises(InvalidIssueType):
             create_issue(project, 'FakeType', 'This is a summary')
 
 
-def test_create__create_issue__adds_issue_to_self_and_calls_write_issues(mock_jira, project):
+def test_create__create_issue__adds_issue_to_dataframe(mock_jira, project):
     '''
-    Ensure create_issue() adds the new Issue to self, and writes the issue cache
+    Ensure create_issue() adds the new Issue to the DataFrame
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary')
 
     assert mock_jira[offline_issue.key]
-    assert mock_jira.write_issues.called
 
 
 def test_create__create_issue__mandatory_fields_are_set_in_new_issue(mock_jira, project):
     '''
     Ensure create_issue() sets the mandatory fields passed as args (not kwargs)
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary')
 
     assert offline_issue.project == project
@@ -81,7 +85,8 @@ def test_create__create_issue__kwargs_are_set_in_new_issue(mock_jira, project):
     # Add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary', epic_link='TEST-1')
 
     assert offline_issue.epic_link == 'TEST-1'
@@ -100,7 +105,8 @@ def test_create__create_issue__kwargs_are_set_in_new_issue_extended(mock_jira, p
     # Add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         offline_issue = create_issue(project, 'Story', 'This is a summary', arbitrary_key='arbitrary_value')
 
     assert offline_issue.extended['arbitrary_key'] == 'arbitrary_value'
@@ -117,7 +123,8 @@ def test_create__create_issue__raises_exception_when_passed_an_unknown_epic_link
     # add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         with pytest.raises(EpicNotFound):
             create_issue(project, 'Story', 'This is summary', epic_link='Nothing')
 
@@ -134,7 +141,8 @@ def test_create__create_issue__issue_is_mapped_to_existing_epic_summary(mock_jir
     # add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         new_issue = create_issue(project, 'Story', 'This is summary', epic_link=epic_link_value)
 
     # assert new Issue to linked to the epic
@@ -148,7 +156,8 @@ def test_create__find_epic_by_reference__match_by_key(mock_jira, project):
     # add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         epic = find_epic_by_reference('TEST-1')
 
     assert epic == mock_jira['TEST-1']
@@ -161,7 +170,8 @@ def test_create__find_epic_by_reference__match_by_summary(mock_jira, project):
     # add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         epic = find_epic_by_reference('This is an epic')
 
     assert epic == mock_jira['TEST-1']
@@ -174,7 +184,8 @@ def test_create__find_epic_by_reference__match_by_epic_name(mock_jira, project):
     # add an Epic fixture to the Jira dict
     mock_jira['TEST-1'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         epic = find_epic_by_reference('0.1: Epic about a thing')
 
     assert epic == mock_jira['TEST-1']
@@ -184,7 +195,8 @@ def test_create__find_epic_by_reference__raise_on_failed_to_match(mock_jira, pro
     '''
     Ensure exception raised when epic not found
     '''
-    with mock.patch('jira_offline.create.jira', mock_jira), mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         with pytest.raises(EpicNotFound):
             find_epic_by_reference('fake epic reference')
 
@@ -199,7 +211,8 @@ def test_create__find_epic_by_reference__raise_on_duplicate_ref_string(mock_jira
     with mock.patch.dict(EPIC_1, {'key': 'TEST-2'}):
         mock_jira['TEST-2'] = Issue.deserialize(EPIC_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira), mock.patch('jira_offline.jira.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         with pytest.raises(EpicSearchStrUsedMoreThanOnce):
             find_epic_by_reference('This is an epic')
 
@@ -365,10 +378,14 @@ def test_create__patch_issue_from_dict__set_string_to_value(mock_jira, project):
     '''
     issue = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'assignee': 'eggs'})
 
     assert issue.assignee == 'eggs'
+    assert issue.commit.called
 
 
 def test_create__patch_issue_from_dict__set_string_to_blank(mock_jira, project):
@@ -377,10 +394,14 @@ def test_create__patch_issue_from_dict__set_string_to_blank(mock_jira, project):
     '''
     issue = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'assignee': ''})
 
     assert issue.assignee is None
+    assert issue.commit.called
 
 
 def test_create__patch_issue_from_dict__set_priority(mock_jira, project):
@@ -389,10 +410,14 @@ def test_create__patch_issue_from_dict__set_priority(mock_jira, project):
     '''
     issue = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'priority': 'Bacon'})
 
     assert issue.priority == 'Bacon'
+    assert issue.commit.called
 
 
 @pytest.mark.parametrize('param', [
@@ -407,12 +432,16 @@ def test_create__patch_issue_from_dict__set_set(mock_jira, project, param):
     with mock.patch.dict(ISSUE_1, {'labels': set(['egg'])}):
         issue = Issue.deserialize(ISSUE_1, project)
 
+    issue.commit = mock.Mock()
+
     assert issue.labels == {'egg'}
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'labels': param})
 
     assert issue.labels == {'egg', 'bacon'}
+    assert issue.commit.called
 
 
 @pytest.mark.skip(reason='Will succeed when there is a list-type field on Issue class')
@@ -428,12 +457,15 @@ def test_create__patch_issue_from_dict__set_list(mock_jira, project, param):
     with mock.patch.dict(ISSUE_1, {'labels': ['egg']}):
         issue = Issue.deserialize(ISSUE_1, project)
 
+    issue.commit = mock.Mock()
+
     assert issue.labels == ['egg']
 
     with mock.patch('jira_offline.create.jira', mock_jira):
         patch_issue_from_dict(issue, {'labels': param})
 
     assert issue.labels == ['egg', 'bacon']
+    assert issue.commit.called
 
 
 @pytest.mark.parametrize('customfield_name', [
@@ -451,10 +483,14 @@ def test_create__patch_issue_from_dict__set_extended_customfield(mock_jira, cust
 
     issue = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {customfield_name: 'eggs'})
 
     assert issue.extended['arbitrary-user-defined-field'] == 'eggs'
+    assert issue.commit.called
 
 
 def test_create__patch_issue_from_dict__ignore_undefined_customfield(mock_jira):
@@ -469,10 +505,14 @@ def test_create__patch_issue_from_dict__ignore_undefined_customfield(mock_jira):
 
     issue = Issue.deserialize(ISSUE_1, project)
 
-    with mock.patch('jira_offline.create.jira', mock_jira):
+    issue.commit = mock.Mock()
+
+    with mock.patch('jira_offline.create.jira', mock_jira), \
+            mock.patch('jira_offline.jira.jira', mock_jira):
         patch_issue_from_dict(issue, {'arbitrary-user-defined-field': 'eggs'})
 
     assert issue.extended == {}
+    assert issue.commit.called
 
 
 def test_create__patch_issue_from_dict__uses_reset_before_edit(mock_jira):
@@ -493,6 +533,8 @@ def test_create__patch_issue_from_dict__uses_reset_before_edit(mock_jira):
     with mock.patch.dict(ISSUE_1, {'sprint': [{'id': 1, 'name': 'Sprint 1', 'active': True}]}):
         issue = Issue.deserialize(ISSUE_1, project)
 
+    issue.commit = mock.Mock()
+
     # Add the issue to another sprint
     issue.sprint.add(Sprint(id=2, name='Sprint 2', active=False))
 
@@ -510,3 +552,4 @@ def test_create__patch_issue_from_dict__uses_reset_before_edit(mock_jira):
         Sprint(id=1, name='Sprint 1', active=True),
         Sprint(id=3, name='Sprint 3', active=False),
     }
+    assert issue.commit.called

--- a/test/test_jira_class.py
+++ b/test/test_jira_class.py
@@ -114,10 +114,15 @@ def test_jira__mutablemapping__in_operator_with_new_issue(mock_jira_core, projec
     assert '7242cc9e-ea52-4e51-bd84-2ced250cabf0' in mock_jira_core
 
 
-@pytest.mark.parametrize('issue_fixture', [ISSUE_1, ISSUE_NEW, EPIC_1])
+@pytest.mark.parametrize('issue_fixture', [
+    ISSUE_1,
+    ISSUE_NEW,
+    EPIC_1,
+])
 def test_jira__mutablemapping__roundtrip(mock_jira, project, issue_fixture):
     '''
     Ensure an issue can be set into the Jira object and be recreated without change.
+
     Parameterized with the various different types of Issue fixtures.
     '''
     # add to dataframe (via __set_item__)
@@ -127,26 +132,6 @@ def test_jira__mutablemapping__roundtrip(mock_jira, project, issue_fixture):
     issue_2 = mock_jira[issue_fixture['key']]
 
     compare_issue_helper(issue_1, issue_2)
-    assert issue_1.original == issue_2.original
-
-
-def test_jira__mutablemapping__roundtrip_with_mod(mock_jira, project):
-    '''
-    Ensure an issue can be set into the Jira object, and be recreated and then modified
-    '''
-    # add to dataframe (via __set_item__)
-    mock_jira['TEST-71'] = issue_1 = Issue.deserialize(ISSUE_1, project)
-
-    # extract back out of dataframe (via __get_item__)
-    issue_2 = mock_jira['TEST-71']
-
-    with mock.patch('jira_offline.jira.jira', mock_jira):
-        setattr(issue_2, 'summary', 'egg')
-
-    assert issue_1.summary == 'This is the story summary'
-    assert issue_2.summary == 'egg'
-    assert issue_1.modified is False
-    assert issue_2.modified is True
     assert issue_1.original == issue_2.original
 
 


### PR DESCRIPTION
Since the move to Pandas, it's not feasible to track modified state via a bool on the `Issue` model in `Issue.modified`.

Remove that field and associated code, and subsequently rename `Issue.diff_to_original` to `Issue.modified` - which sounds confusing but makes the test for modified issues much cleaner:

    jira.df[df.modified]